### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Ensure you have the following environment variables set:
 
 ```bash
 ANTHROPIC_API_KEY   # your Anthropic API key
-OPENAPI_API_KEY     # your Openai API key, or ...
+OPENAI_API_KEY     # your Openai API key, or ...
 GOOGLE_API_KEY      # your Gemini API key
 EDITOR              # set this to your favorite terminal editor (vim or emacs or whatever) so you can /edit messages or /edit_ast the Python code before it gets executed etc.
 ```


### PR DESCRIPTION
Fix typo in README.md.

Due to the typo, I had set the environment variable as OPENAPI_API_KEY.
Using LLMVM_EXECUTOR="openai" LLMVM_MODEL="gpt-4o" was falling into
the else block and using an AnthropicExecutor since there was also an
ANTHROPIC_API_KEY in the environment. When "openai" is provided as an
executor, it should use an OpenAIExecutor or error out.
